### PR TITLE
fix(cli): accept prerelease/build Kirby CLI versions

### DIFF
--- a/src/Cli/KirbyCliHelpParser.php
+++ b/src/Cli/KirbyCliHelpParser.php
@@ -29,7 +29,7 @@ final class KirbyCliHelpParser
                 continue;
             }
 
-            if ($cliVersion === null && preg_match('/^Kirby\\s+CLI\\s+v?([0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\\b/i', $line, $m) === 1) {
+            if ($cliVersion === null && preg_match('/^Kirby\\s+CLI\\s+v?([0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.+-]+)?)\\b/i', $line, $m) === 1) {
                 $cliVersion = $m[1];
                 continue;
             }

--- a/src/Cli/KirbyCliHelpParser.php
+++ b/src/Cli/KirbyCliHelpParser.php
@@ -29,7 +29,7 @@ final class KirbyCliHelpParser
                 continue;
             }
 
-            if ($cliVersion === null && preg_match('/^Kirby\\s+CLI\\s+([0-9]+\\.[0-9]+\\.[0-9]+)$/i', $line, $m) === 1) {
+            if ($cliVersion === null && preg_match('/^Kirby\\s+CLI\\s+v?([0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\\b/i', $line, $m) === 1) {
                 $cliVersion = $m[1];
                 continue;
             }

--- a/tests/Unit/KirbyCliHelpParserTest.php
+++ b/tests/Unit/KirbyCliHelpParserTest.php
@@ -27,9 +27,9 @@ TEXT;
     expect($parsed['sections']['core'])->toContain('version');
 });
 
-it('parses `kirby help` output with prerelease CLI versions', function (): void {
+it('parses `kirby help` output with prerelease and build metadata versions', function (): void {
     $stdout = <<<TEXT
-Kirby CLI v2.0.0-beta.1
+Kirby CLI v2.0.0-beta.1+build.42
 
 Core commands:
 - kirby version
@@ -37,7 +37,7 @@ TEXT;
 
     $parsed = KirbyCliHelpParser::parse($stdout);
 
-    expect($parsed['cliVersion'])->toBe('2.0.0-beta.1');
+    expect($parsed['cliVersion'])->toBe('2.0.0-beta.1+build.42');
     expect($parsed['commands'])->toContain('version');
 });
 

--- a/tests/Unit/KirbyCliHelpParserTest.php
+++ b/tests/Unit/KirbyCliHelpParserTest.php
@@ -27,6 +27,20 @@ TEXT;
     expect($parsed['sections']['core'])->toContain('version');
 });
 
+it('parses `kirby help` output with prerelease CLI versions', function (): void {
+    $stdout = <<<TEXT
+Kirby CLI v2.0.0-beta.1
+
+Core commands:
+- kirby version
+TEXT;
+
+    $parsed = KirbyCliHelpParser::parse($stdout);
+
+    expect($parsed['cliVersion'])->toBe('2.0.0-beta.1');
+    expect($parsed['commands'])->toContain('version');
+});
+
 it('parses `kirby <command> --help` usage output into args', function (): void {
     $stdout = <<<TEXT
 Displays Kirby license information in table or JSON format.


### PR DESCRIPTION
### Motivation

- Make Kirby CLI help parsing more resilient by accepting `v` prefixes and prerelease/build metadata (e.g. `v2.0.0-beta.1`) so MCP tools correctly detect CLI versions in real-world outputs.

### Description

- Broadened the Kirby CLI version regex in `KirbyCliHelpParser::parse` to match optional `v` prefix and semver prerelease/build suffixes.
- Added a unit test `tests/Unit/KirbyCliHelpParserTest.php` to cover parsing of prerelease CLI versions.
- Files changed: `src/Cli/KirbyCliHelpParser.php` and `tests/Unit/KirbyCliHelpParserTest.php`.

### Testing

- Added unit test `tests/Unit/KirbyCliHelpParserTest.php` which exercises prerelease parsing and is expected to pass under the normal dev environment.
- Attempted to run `vendor/bin/pest tests/Unit/KirbyCliHelpParserTest.php` locally but it failed due to missing dev dependencies (`vendor/bin/pest` not installed) in this environment.
- Recommended verification: run `composer install` then `composer test` (or `vendor/bin/pest tests/Unit/KirbyCliHelpParserTest.php`) in CI or a local dev setup; CI GitHub Actions run `composer cms:starterkit` then `vendor/bin/pest --ci` which should validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698901624e8483219183a7e65e5ec8e9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CLI version detection to support broader version string formats. Now accepts optional leading 'v' prefix and prerelease/build metadata (e.g., v2.0.0-beta.1, 1.2.3+build), improving compatibility with modern version naming conventions.

* **Tests**
  * Added comprehensive test coverage for prerelease CLI version parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->